### PR TITLE
BLS - QCEW File name assumption causes failure.

### DIFF
--- a/tasks/us/bls.py
+++ b/tasks/us/bls.py
@@ -34,7 +34,13 @@ class RawQCEW(CSV2TempTableTask):
         return DownloadQCEW(year=self.year)
 
     def input_csv(self):
-        return os.path.join(self.input().path, '{}.q1-q4.singlefile.csv'.format(self.year))
+        # Depending on year of extract, file name changes -- assumption that q4 is present is too strict
+        # The below may not even work when only 1 quarter of year is present? 
+        for qtr_no_ in [1, 2, 3, 4]:
+            out_file_ = os.path.join(self.input().path, '{0}.q1-q{1}.singlefile.csv'.format(self.year, qtr_no_))
+            if os.path.isfile(out_file_):
+                return out_file_
+
 
 
 class SimpleQCEW(TempTableTask):


### PR DESCRIPTION
Appreciate what you're doing here.  I've come across a small corner case on the us.bls extract.

You've implicitly assumed one would only extract full year such that q1-q4 would be contained in the input_csv file name.  Currently 2016 is named as q1-q3 so the load fails due to input_csv returned invalid file.  I don't know if when 2017.1 is available they will name it q1-q1 (seems unlikely) but I don't want to make the assumption as of yet. 

I may have overlooked something in the implementation but figured I'd at least raise it to your attention. 



