### PR TITLE
Canada geometry names

### DIFF
--- a/tasks/ca/statcan/data.py
+++ b/tasks/ca/statcan/data.py
@@ -258,6 +258,7 @@ class AllCensusTopics(BaseParams, WrapperTask):
 
 
 class NHS(Survey):
+
     def requires(self):
         return {
             'data': CopyDataToTable(resolution=self.resolution, survey=SURVEY_NHS, topic=self.topic),

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -140,6 +140,7 @@ class GeographyColumns(ColumnsTask):
         geom_name = OBSColumn(
             type='Text',
             weight=1,
+            name='Name of ' + GEOGRAPHY_NAMES[self.resolution],
             targets={geom: GEOM_NAME},
             tags=[sections['ca'], subsections['names']]
         )

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -175,7 +175,7 @@ class Geography(TableTask):
     def populate(self):
         session = current_session()
         session.execute('INSERT INTO {output} '
-                        'SELECT {name} as geom_name '
+                        'SELECT {name} as geom_name, '
                         '       {code}uid as geom_id, '
                         '       wkb_geometry as geom '
                         'FROM {input} '.format(

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -3,7 +3,7 @@ from luigi import Parameter, WrapperTask
 from tasks.util import (DownloadUnzipTask, shell, Shp2TempTableTask,
                         ColumnsTask, TableTask)
 from tasks.meta import GEOM_REF, GEOM_NAME, OBSColumn, current_session
-from tasks.tags import SectionTags, SubsectionTags
+from tasks.tags import SectionTags, SubsectionTags, BoundaryTags
 
 from collections import OrderedDict
 
@@ -110,7 +110,7 @@ class GeographyColumns(ColumnsTask):
     }
 
     def version(self):
-        return 12
+        return 13
 
     def requires(self):
         return {
@@ -144,6 +144,7 @@ class GeographyColumns(ColumnsTask):
             targets={geom: GEOM_NAME},
             tags=[sections['ca'], subsections['names']]
         )
+        geom.tags.extend(boundary_type[i] for i in GEOGRAPHY_TAGS[self.resolution])
 
         return OrderedDict([
             ('geom_name', geom_name),
@@ -159,7 +160,7 @@ class Geography(TableTask):
     resolution = Parameter(default=GEO_PR)
 
     def version(self):
-        return 7
+        return 8
 
     def requires(self):
         return {

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -3,7 +3,7 @@ from luigi import Parameter, WrapperTask
 from tasks.util import (DownloadUnzipTask, shell, Shp2TempTableTask,
                         ColumnsTask, TableTask)
 from tasks.meta import GEOM_REF, GEOM_NAME, OBSColumn, current_session
-from tasks.tags import SectionTags, SubsectionTags, BoundaryTags
+from tasks.tags import SectionTags, SubsectionTags
 
 from collections import OrderedDict
 
@@ -190,3 +190,9 @@ class AllGeographies(WrapperTask):
     def requires(self):
         for resolution in GEOGRAPHIES:
             yield Geography(resolution=resolution)
+
+class AllGeographyColumns(WrapperTask):
+
+    def requires(self):
+        for resolution in GEOGRAPHIES:
+            yield GeographyColumns(resolution=resolution)

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -181,7 +181,7 @@ class Geography(TableTask):
                         '       {code}uid as geom_id, '
                         '       wkb_geometry as geom '
                         'FROM {input} '.format(
-                            name=GEOGRAPHY_PROPERNAMES[self.resolution()],
+                            name=GEOGRAPHY_PROPERNAMES[self.resolution],
                             output=self.output().table,
                             code=self.resolution.replace('_', ''),
                             input=self.input()['data'].table))

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -143,7 +143,7 @@ class GeographyColumns(ColumnsTask):
             targets={geom: GEOM_NAME},
             tags=[sections['ca'], subsections['names']]
         )
-        geom.tags.extend(boundary_type[i] for i in GEOGRAPHY_TAGS[self.resolution])
+
         return OrderedDict([
             ('geom_name', geom_name),
             ('geom_id', geom_id),   # cvegeo


### PR DESCRIPTION
Adding geometry names for Canadian provinces + territories, census tracts, census divisions, census subdivisions, and census metropolitan areas and census agglomerations.

Assuming that all name codes are "RESOLUTION+NAME" (eg. "CTNAME")