### PR TITLE
add missing metawrapper for es/ine.py householdshousing

### DIFF
--- a/tasks/es/ine.py
+++ b/tasks/es/ine.py
@@ -1998,3 +1998,11 @@ class FiveYearPopulationMeta(MetaWrapper):
     def tables(self):
         yield FiveYearPopulation()
         yield Geometry()
+
+
+class PopulationHouseholdsHousingMeta(MetaWrapper):
+
+    def tables(self):
+        yield PopulationHouseholdsHousing()
+        yield Geometry()
+


### PR DESCRIPTION
This adds the missing `MetaWrapper` we found whose absence orphaned the [es.ine.PopulationHouseholdsHousing](https://github.com/CartoDB/bigmetadata/blob/master/tasks/es/ine.py#L1735) `TableTask`.

Answers questions brought up by @rafatower @javitonino .  Should be OK to merge.