### PR TITLE
Public tags

### DIFF
--- a/tasks/ca/statcan/cols_census.py
+++ b/tasks/ca/statcan/cols_census.py
@@ -9752,7 +9752,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c001_t: DENOMINATOR },)
 
         t005c008_t = OBSColumn(
@@ -9761,7 +9761,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c007_t: DENOMINATOR },)
 
         t005c009_t = OBSColumn(
@@ -9770,7 +9770,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c008_t: DENOMINATOR },)
 
         t005c010_t = OBSColumn(
@@ -9779,7 +9779,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c008_t: DENOMINATOR },)
 
         t005c011_t = OBSColumn(
@@ -9788,7 +9788,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c010_t: DENOMINATOR },)
 
         t005c012_t = OBSColumn(
@@ -9797,7 +9797,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c010_t: DENOMINATOR },)
 
         t005c013_t = OBSColumn(
@@ -9806,7 +9806,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c010_t: DENOMINATOR },)
 
         t005c014_t = OBSColumn(
@@ -9815,7 +9815,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c007_t: DENOMINATOR },)
 
         t005c015_t = OBSColumn(
@@ -9824,7 +9824,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c014_t: DENOMINATOR },)
 
         t005c016_t = OBSColumn(
@@ -9833,7 +9833,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c014_t: DENOMINATOR },)
 
         t005c017_t = OBSColumn(
@@ -9842,7 +9842,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c016_t: DENOMINATOR },)
 
         t005c018_t = OBSColumn(
@@ -9851,7 +9851,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c016_t: DENOMINATOR },)
 
         t005c019_t = OBSColumn(
@@ -9860,7 +9860,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_households, subsections['families']],
+            tags=[ca, unit_households, subsections['families'], public],
             targets={ t005c016_t: DENOMINATOR },)
 
         t005c020_t = OBSColumn(
@@ -9869,7 +9869,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['families']],
+            tags=[ca, unit_people, subsections['families'], public],
             targets={ t005c001_t: DENOMINATOR },)
 
         t005c021_t = OBSColumn(
@@ -9878,7 +9878,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['families']],
+            tags=[ca, unit_people, subsections['families'], public],
             targets={ t005c020_t: DENOMINATOR },)
 
         t005c022_t = OBSColumn(
@@ -9887,7 +9887,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['families']],
+            tags=[ca, unit_people, subsections['families'], public],
             targets={ t005c021_t: DENOMINATOR },)
 
         t005c023_t = OBSColumn(
@@ -9896,7 +9896,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['families']],
+            tags=[ca, unit_people, subsections['families'], public],
             targets={ t005c021_t: DENOMINATOR },)
 
         t005c024_t = OBSColumn(
@@ -9905,7 +9905,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['families']],
+            tags=[ca, unit_people, subsections['families'], public],
             targets={ t005c021_t: DENOMINATOR },)
 
         t005c025_t = OBSColumn(
@@ -9914,7 +9914,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['families']],
+            tags=[ca, unit_people, subsections['families'], public],
             targets={ t005c020_t: DENOMINATOR },)
 
         t005c026_t = OBSColumn(
@@ -9923,7 +9923,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['families']],
+            tags=[ca, unit_people, subsections['families'], public],
             targets={ t005c025_t: DENOMINATOR },)
 
         t005c027_t = OBSColumn(
@@ -9932,7 +9932,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['families']],
+            tags=[ca, unit_people, subsections['families'], public],
             targets={ t005c025_t: DENOMINATOR },)
 
         t005c028_t = OBSColumn(
@@ -9941,7 +9941,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['families']],
+            tags=[ca, unit_people, subsections['families'], public],
             targets={ t005c025_t: DENOMINATOR },)
 
         t005c029_t = OBSColumn(

--- a/tasks/ca/statcan/cols_census.py
+++ b/tasks/ca/statcan/cols_census.py
@@ -1,6 +1,6 @@
 from tasks.meta import OBSColumn, DENOMINATOR, UNIVERSE
 from tasks.util import ColumnsTask
-from tasks.tags import SectionTags, SubsectionTags, UnitTags
+from tasks.tags import SectionTags, SubsectionTags, UnitTags, PublicTags
 from tasks.ca.statcan.license import LicenseTags, SourceTags
 
 from collections import OrderedDict
@@ -15,6 +15,7 @@ class CensusColumns(ColumnsTask):
             'units': UnitTags(),
             'license': LicenseTags(),
             'source': SourceTags(),
+            'public': PublicTags()
         }
 
     def version(self):
@@ -26,6 +27,7 @@ class CensusColumns(ColumnsTask):
         source = input_['source']['statcan-census-2011']
 
         subsections = input_['subsections']
+        public = input_['public']['public']
 
         unit_people = input_['units']['people']
         unit_housing = input_['units']['housing_units']
@@ -42,25 +44,25 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={},)
 
         t001c001_m = OBSColumn(
             id='t001c001_m',
-            name='Total population (male)',
+            name='Total male population',
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={},)
 
         t001c001_f = OBSColumn(
             id='t001c001_f',
-            name='Total population (female)',
+            name='Total female population',
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={},)
 
         t001c002_t = OBSColumn(
@@ -69,7 +71,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c002_m = OBSColumn(
@@ -78,7 +80,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c002_f = OBSColumn(
@@ -87,7 +89,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c003_t = OBSColumn(
@@ -96,7 +98,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c003_m = OBSColumn(
@@ -105,7 +107,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c003_f = OBSColumn(
@@ -114,7 +116,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c004_t = OBSColumn(
@@ -123,7 +125,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c004_m = OBSColumn(
@@ -132,7 +134,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c004_f = OBSColumn(
@@ -141,7 +143,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c005_t = OBSColumn(
@@ -150,7 +152,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c005_m = OBSColumn(
@@ -159,7 +161,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c005_f = OBSColumn(
@@ -168,7 +170,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c006_t = OBSColumn(
@@ -177,7 +179,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_t: DENOMINATOR },)
 
         t001c006_m = OBSColumn(
@@ -186,7 +188,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_m: DENOMINATOR },)
 
         t001c006_f = OBSColumn(
@@ -195,7 +197,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_f: DENOMINATOR },)
 
         t001c007_t = OBSColumn(
@@ -204,7 +206,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_t: DENOMINATOR },)
 
         t001c007_m = OBSColumn(
@@ -213,7 +215,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_m: DENOMINATOR },)
 
         t001c007_f = OBSColumn(
@@ -222,7 +224,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_f: DENOMINATOR },)
 
         t001c008_t = OBSColumn(
@@ -231,7 +233,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_t: DENOMINATOR },)
 
         t001c008_m = OBSColumn(
@@ -240,7 +242,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_m: DENOMINATOR },)
 
         t001c008_f = OBSColumn(
@@ -249,7 +251,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_f: DENOMINATOR },)
 
         t001c009_t = OBSColumn(
@@ -258,7 +260,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_t: DENOMINATOR },)
 
         t001c009_m = OBSColumn(
@@ -267,7 +269,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_m: DENOMINATOR },)
 
         t001c009_f = OBSColumn(
@@ -276,7 +278,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_f: DENOMINATOR },)
 
         t001c010_t = OBSColumn(
@@ -285,7 +287,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_t: DENOMINATOR },)
 
         t001c010_m = OBSColumn(
@@ -294,7 +296,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_m: DENOMINATOR },)
 
         t001c010_f = OBSColumn(
@@ -303,7 +305,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c005_f: DENOMINATOR },)
 
         t001c011_t = OBSColumn(
@@ -312,7 +314,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c011_m = OBSColumn(
@@ -321,7 +323,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c011_f = OBSColumn(
@@ -330,7 +332,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c012_t = OBSColumn(
@@ -339,7 +341,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c012_m = OBSColumn(
@@ -348,7 +350,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c012_f = OBSColumn(
@@ -357,7 +359,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c013_t = OBSColumn(
@@ -366,7 +368,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c013_m = OBSColumn(
@@ -375,7 +377,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c013_f = OBSColumn(
@@ -384,7 +386,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c014_t = OBSColumn(
@@ -393,7 +395,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c014_m = OBSColumn(
@@ -402,7 +404,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c014_f = OBSColumn(
@@ -411,7 +413,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c015_t = OBSColumn(
@@ -420,7 +422,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c015_m = OBSColumn(
@@ -429,7 +431,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c015_f = OBSColumn(
@@ -438,7 +440,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c016_t = OBSColumn(
@@ -447,7 +449,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c016_m = OBSColumn(
@@ -456,7 +458,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c016_f = OBSColumn(
@@ -465,7 +467,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c017_t = OBSColumn(
@@ -474,7 +476,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c017_m = OBSColumn(
@@ -483,7 +485,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c017_f = OBSColumn(
@@ -492,7 +494,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c018_t = OBSColumn(
@@ -501,7 +503,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c018_m = OBSColumn(
@@ -510,7 +512,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c018_f = OBSColumn(
@@ -519,7 +521,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c019_t = OBSColumn(
@@ -528,7 +530,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c019_m = OBSColumn(
@@ -537,7 +539,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c019_f = OBSColumn(
@@ -546,7 +548,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c020_t = OBSColumn(
@@ -555,7 +557,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c020_m = OBSColumn(
@@ -564,7 +566,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c020_f = OBSColumn(
@@ -573,7 +575,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c021_t = OBSColumn(
@@ -582,7 +584,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c021_m = OBSColumn(
@@ -591,7 +593,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c021_f = OBSColumn(
@@ -600,7 +602,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c022_t = OBSColumn(
@@ -609,7 +611,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c022_m = OBSColumn(
@@ -618,7 +620,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c022_f = OBSColumn(
@@ -627,7 +629,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c023_t = OBSColumn(
@@ -636,7 +638,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c023_m = OBSColumn(
@@ -645,7 +647,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c023_f = OBSColumn(
@@ -654,7 +656,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c024_t = OBSColumn(
@@ -663,7 +665,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_t: DENOMINATOR },)
 
         t001c024_m = OBSColumn(
@@ -672,7 +674,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_m: DENOMINATOR },)
 
         t001c024_f = OBSColumn(
@@ -681,7 +683,7 @@ class CensusColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['age_gender']],
+            tags=[ca, unit_people, subsections['age_gender'], public],
             targets={ t001c001_f: DENOMINATOR },)
 
         t001c025_t = OBSColumn(

--- a/tasks/ca/statcan/cols_nhs.py
+++ b/tasks/ca/statcan/cols_nhs.py
@@ -1,6 +1,6 @@
 from tasks.meta import OBSColumn, DENOMINATOR, UNIVERSE
 from tasks.util import ColumnsTask
-from tasks.tags import SectionTags, SubsectionTags, UnitTags
+from tasks.tags import SectionTags, SubsectionTags, UnitTags, PublicTags
 from tasks.ca.statcan.license import LicenseTags, SourceTags
 
 from collections import OrderedDict
@@ -15,6 +15,7 @@ class NHSColumns(ColumnsTask):
             'units': UnitTags(),
             'license': LicenseTags(),
             'source': SourceTags(),
+            'public': PublicTags()
         }
 
     def version(self):
@@ -26,6 +27,8 @@ class NHSColumns(ColumnsTask):
         source = input_['source']['statcan-nhs-2011']
 
         subsections = input_['subsections']
+
+        public = input_['public']['public']
 
         unit_people = input_['units']['people']
         unit_money = input_['units']['money']
@@ -719,7 +722,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['employment']],
+            tags=[ca, unit_people, subsections['employment'], public],
             targets={},)
 
         t004c001_m = OBSColumn(
@@ -854,7 +857,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['employment'], subsections['education'], public],
             targets={},)
 
         t005c001_m = OBSColumn(
@@ -1124,7 +1127,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={},)
 
         t005c011_m = OBSColumn(
@@ -1151,7 +1154,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c011_t: DENOMINATOR },)
 
         t005c012_m = OBSColumn(
@@ -1178,7 +1181,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c011_t: DENOMINATOR },)
 
         t005c013_m = OBSColumn(
@@ -1205,7 +1208,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c011_t: DENOMINATOR },)
 
         t005c014_m = OBSColumn(
@@ -1232,7 +1235,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c014_t: DENOMINATOR },)
 
         t005c015_m = OBSColumn(
@@ -1259,7 +1262,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c014_t: DENOMINATOR },)
 
         t005c016_m = OBSColumn(
@@ -1286,7 +1289,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c014_t: DENOMINATOR },)
 
         t005c017_m = OBSColumn(
@@ -1313,7 +1316,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c014_t: DENOMINATOR },)
 
         t005c018_m = OBSColumn(
@@ -1340,7 +1343,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c018_t: DENOMINATOR },)
 
         t005c019_m = OBSColumn(
@@ -1367,7 +1370,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c018_t: DENOMINATOR },)
 
         t005c020_m = OBSColumn(
@@ -1394,7 +1397,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['education']],
+            tags=[ca, unit_people, subsections['education'], public],
             targets={ t005c001_t: DENOMINATOR },)
 
         t005c022_m = OBSColumn(
@@ -9206,7 +9209,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_household, subsections['housing']],
+            tags=[ca, unit_household, subsections['housing'], public],
             targets={ t009c001_t: DENOMINATOR },)
 
         t009c003_t = OBSColumn(
@@ -9215,7 +9218,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_household, subsections['housing']],
+            tags=[ca, unit_household, subsections['housing'], public],
             targets={ t009c001_t: DENOMINATOR },)
 
         t009c004_t = OBSColumn(
@@ -11645,7 +11648,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='median',
-            tags=[ca, unit_money, subsections['income']],
+            tags=[ca, unit_money, subsections['income'], public],
             targets={ t012c001_t: UNIVERSE },)
 
         t012c031_t = OBSColumn(
@@ -14810,7 +14813,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['employment']],
+            tags=[ca, unit_people, subsections['employment'], public],
             targets={ t005c001_t: DENOMINATOR },)
 
         t015c002_m = OBSColumn(
@@ -14837,7 +14840,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['employment']],
+            tags=[ca, unit_people, subsections['employment'], public],
             targets={ t015c002_t: DENOMINATOR },)
 
         t015c003_m = OBSColumn(
@@ -14864,7 +14867,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['employment']],
+            tags=[ca, unit_people, subsections['employment'], public],
             targets={ t015c002_t: DENOMINATOR },)
 
         t015c004_m = OBSColumn(
@@ -14891,7 +14894,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['employment']],
+            tags=[ca, unit_people, subsections['employment'], public],
             targets={ t005c001_t: DENOMINATOR },)
 
         t015c005_m = OBSColumn(
@@ -19724,7 +19727,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={},)
 
         t022c002_t = OBSColumn(
@@ -19751,7 +19754,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c006_t = OBSColumn(
@@ -19760,7 +19763,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c007_t = OBSColumn(
@@ -19769,7 +19772,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c008_t = OBSColumn(
@@ -19778,7 +19781,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c009_t = OBSColumn(
@@ -19787,7 +19790,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c010_t = OBSColumn(
@@ -19796,7 +19799,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c012_t = OBSColumn(
@@ -19805,7 +19808,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c013_t = OBSColumn(
@@ -19814,7 +19817,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c014_t = OBSColumn(
@@ -19823,7 +19826,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c015_t = OBSColumn(
@@ -19832,7 +19835,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c016_t = OBSColumn(
@@ -19841,7 +19844,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c017_t = OBSColumn(
@@ -19850,7 +19853,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='average',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={},)
 
         t022c019_t = OBSColumn(
@@ -19859,7 +19862,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c020_t = OBSColumn(
@@ -19868,7 +19871,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c021_t = OBSColumn(
@@ -19877,7 +19880,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t022c022_t = OBSColumn(
@@ -19886,7 +19889,7 @@ class NHSColumns(ColumnsTask):
             type='Numeric',
             weight=3,
             aggregate='sum',
-            tags=[ca, unit_people, subsections['housing']],
+            tags=[ca, unit_people, subsections['housing'], public],
             targets={ t022c001_t: DENOMINATOR },)
 
         t023c001_t = OBSColumn(

--- a/tasks/tags.py
+++ b/tasks/tags.py
@@ -328,3 +328,14 @@ class BoundaryTags(TagsTask):
                    type='boundary_type',
                    description='Boundary appropriate for cartographic use'),
             ]
+
+class PublicTags(TagsTask):
+    def version(self):
+        return 1
+    def tags(self):
+        return [
+            OBSTag(id='public',
+                   name='Key variable',
+                   type='public_type',
+                   description='This tag is a flag for key variables')
+        ]


### PR DESCRIPTION
Creating and adding a new tag called "public" to 109 variables from Canada's Census and NHS survey. This PR is to start reducing variables to a few hundred key variables as discussed in this issue: https://github.com/CartoDB/bigmetadata/issues/169.

After running 

`make -- run ca.statcan.cols_census CensusColumns`
and `make -- run ca.statcan.cols_nhs NHSColumns`

You can find the 109 Canadian variables tagged as "public" by opening psql (`make psql`) and querying:

```
select C.* from observatory.obs_column C inner join observatory.obs_column_tag T on C.id = T.column_id where T.column_id like 'ca.%' and T.tag_id like 'tags.public'
```

This tag can be used to isolate the limited key variables we can publish to Builder users via the DO UI.