### PR TITLE
Sort geometries

### DIFF
--- a/tasks/ca/statcan/data.py
+++ b/tasks/ca/statcan/data.py
@@ -148,6 +148,9 @@ class Survey(BaseParams, TableTask):
 
     topic = Parameter(default='t001')
 
+    def version(self):
+        return 4
+
     def requires(self):
         '''
         Subclasses must override this.
@@ -203,9 +206,6 @@ class Survey(BaseParams, TableTask):
 
 
 class Census(Survey):
-
-    def version(self):
-        return 4
 
     def requires(self):
         return {

--- a/tasks/ca/statcan/data.py
+++ b/tasks/ca/statcan/data.py
@@ -203,6 +203,10 @@ class Survey(BaseParams, TableTask):
 
 
 class Census(Survey):
+
+    def version(self):
+        return 4
+
     def requires(self):
         return {
             'data': CopyDataToTable(resolution=self.resolution, survey=SURVEY_CEN, topic=self.topic),

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -142,7 +142,7 @@ class Geography(TableTask):
     resolution = Parameter(default=GEO_PR)
 
     def version(self):
-        return 2
+        return 3
 
     def requires(self):
         return {

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -52,7 +52,7 @@ GEOGRAPHY_TAGS = {
     GEO_PR: ['cartographic_boundary', 'interpolation_boundary'],
     GEO_CD: ['cartographic_boundary', 'interpolation_boundary'],
     GEO_CSD: ['cartographic_boundary', 'interpolation_boundary'],
-    GEO_CMA: [],
+    GEO_CMA: ['cartographic_boundary', 'interpolation_boundary']
 }
 
 
@@ -102,7 +102,7 @@ class GeographyColumns(ColumnsTask):
     }
 
     def version(self):
-        return 8
+        return 11
 
     def requires(self):
         return {
@@ -124,6 +124,7 @@ class GeographyColumns(ColumnsTask):
             tags=[sections['ca'], subsections['boundary']],
         )
         geom_id = OBSColumn(
+            id=self.resolution + '_id',
             type='Text',
             weight=0,
             targets={geom: GEOM_REF},
@@ -142,7 +143,7 @@ class Geography(TableTask):
     resolution = Parameter(default=GEO_PR)
 
     def version(self):
-        return 3
+        return 6
 
     def requires(self):
         return {

--- a/tasks/us/census/tiger.py
+++ b/tasks/us/census/tiger.py
@@ -666,10 +666,10 @@ class ShorelineClip(TableTask):
         session = current_session()
         stmt = ('INSERT INTO {output} '
                 'SELECT geoid, ST_Union(ST_MakePolygon(ST_ExteriorRing(the_geom))) AS the_geom, '
-                '       MAX(aland) AS aland, cdb_observatory.FIRST(name) AS name '
+                '       MAX(aland) AS aland '
                 'FROM ( '
                 '    SELECT geoid, (ST_Dump(the_geom)).geom AS the_geom, '
-                '           aland, name '
+                '           aland '
                 '    FROM {input} '
                 ") holes WHERE GeometryType(the_geom) = 'POLYGON' "
                 'GROUP BY geoid'.format(

--- a/tasks/us/census/tiger.py
+++ b/tasks/us/census/tiger.py
@@ -71,18 +71,20 @@ class ClippedGeomColumns(ColumnsTask):
             )
 
         interpolated_boundaries = ['block_clipped', 'block_group_clipped',
-                                    'puma_clipped','census_tract_clipped',
-                                    'county_clipped','state_clipped']
+                                   'puma_clipped','census_tract_clipped',
+                                   'county_clipped','state_clipped',
+                                   'congressional_district_clipped',
+                                   'zcta5_clipped']
         cartographic_boundaries = ['cbsa_clipped',
-                                    'school_district_elementary_clipped',
-                                    'place_clipped',
-                                    'school_district_secondary_clipped',
-                                    'zcta5_clipped',
-                                    'congressional_district_clipped',
-                                    'school_district_unified_clipped',
-                                    'block_clipped', 'block_group_clipped',
-                                    'puma_clipped','census_tract_clipped',
-                                    'county_clipped','state_clipped']
+                                   'school_district_elementary_clipped',
+                                   'place_clipped',
+                                   'school_district_secondary_clipped',
+                                   'zcta5_clipped',
+                                   'congressional_district_clipped',
+                                   'school_district_unified_clipped',
+                                   'block_clipped', 'block_group_clipped',
+                                   'puma_clipped','census_tract_clipped',
+                                   'county_clipped','state_clipped']
         for colname, col in cols.iteritems():
             if colname in interpolated_boundaries:
                 col.tags.append(boundary_type['interpolation_boundary'])
@@ -129,7 +131,7 @@ class GeomColumns(ColumnsTask):
                 type='Geometry',
                 name='US Census Blocks',
                 description=self._generate_desc("block"),
-                weight=0,
+                weight=11,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'census_tract': OBSColumn(
@@ -143,70 +145,70 @@ class GeomColumns(ColumnsTask):
                 type='Geometry',
                 name='US Congressional Districts',
                 description=self._generate_desc("congressional_district"),
-                weight=5.4,
+                weight=2,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'county': OBSColumn(
                 type='Geometry',
                 name='US County',
                 description=self._generate_desc("county"),
-                weight=7,
+                weight=5,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'puma': OBSColumn(
                 type='Geometry',
                 name='US Census Public Use Microdata Areas',
                 description=self._generate_desc("puma"),
-                weight=5.5,
+                weight=4,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'state': OBSColumn(
                 type='Geometry',
                 name='US States',
                 description=self._generate_desc("state"),
-                weight=8,
+                weight=1,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'zcta5': OBSColumn(
                 type='Geometry',
                 name='US Census Zip Code Tabulation Areas',
                 description=self._generate_desc('zcta5'),
-                weight=6,
+                weight=8,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'school_district_elementary': OBSColumn(
                 type='Geometry',
                 name='Elementary School District',
                 description=self._generate_desc('school_district_elementary'),
-                weight=2.8,
+                weight=6.2,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'school_district_secondary': OBSColumn(
                 type='Geometry',
                 name='Secondary School District',
                 description=self._generate_desc('school_district_secondary'),
-                weight=2.9,
+                weight=6.1,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'school_district_unified': OBSColumn(
                 type='Geometry',
                 name='Unified School District',
                 description=self._generate_desc('school_district_unified'),
-                weight=5,
+                weight=6,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'cbsa': OBSColumn(
                 type='Geometry',
                 name='Core Based Statistical Area (CBSA)',
                 description=self._generate_desc("cbsa"),
-                weight=1,
+                weight=3,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
             'place': OBSColumn(
                 type='Geometry',
                 name='Incorporated Places',
                 description=self._generate_desc("place"),
-                weight=1.1,
+                weight=7,
                 tags=[sections['united_states'], subsections['boundary']]
             ),
         }

--- a/tasks/us/census/tiger.py
+++ b/tasks/us/census/tiger.py
@@ -34,7 +34,7 @@ class TigerSourceTags(TagsTask):
 class ClippedGeomColumns(ColumnsTask):
 
     def version(self):
-        return 13
+        return 14
 
     def requires(self):
         return {
@@ -96,7 +96,7 @@ class ClippedGeomColumns(ColumnsTask):
 class GeomColumns(ColumnsTask):
 
     def version(self):
-        return 15
+        return 16
 
     def requires(self):
         return {


### PR DESCRIPTION
### Additions

- Added congressional districts and zcta5 as interpolate geometries
- Changed the weight for the TIGER geometries in order to make it possible to be sorted

### Fixes

- Added version method for the Survey task in Canadian NHS data
- Removed unused parameter in us.tiger.ShorelineClip task which makes the geometries generation fail
