### PR TITLE
Fix cusec_id generation for Households task

### DIFF
--- a/tasks/es/ine.py
+++ b/tasks/es/ine.py
@@ -1762,7 +1762,7 @@ class PopulationHouseholdsHousing(TableTask):
         session = current_session()
         with self.input()['data'].open() as infile:
             for fields in csv.reader(infile):
-                cusec = "'" + ''.join(fields[0:5]) + "'"
+                cusec = "'" + ''.join(fields[1:5]) + "'"
                 fields = [f.replace('"', '') for f in fields[5:]]
                 fields = [f or 'NULL' for f in fields]
                 fields.insert(0, cusec)
@@ -2005,4 +2005,3 @@ class PopulationHouseholdsHousingMeta(MetaWrapper):
     def tables(self):
         yield PopulationHouseholdsHousing()
         yield Geometry()
-


### PR DESCRIPTION
This solves null problem when installing the population data locally with
`docker-compose run --rm bigmetadata luigi --module tasks.es.ine PopulationHouseholdsHousingMeta`. If you import this, it will always return `null` for the imported measures, because the geometry ids do not match the data ids.

This is not a problem in the deployed version, probably it has been fixed manually in the ETL machine. I did not bother bumping version because of this.

This changes the generation of cusec_id:

CUSED_ID is PPMMMDDCCC
P=provincia
M=municipio
D=distrito
C=seccion censal

The old code also added an additional two ciphers at the beginning for "comunidad autónoma" which does not match how the rest of ids are generated (geometries and population data do not include CCAA).