### PR TITLE
244 tile summary generation review

### DIFF
--- a/tasks/util.py
+++ b/tasks/util.py
@@ -1,3 +1,5 @@
+201708170906
+
 '''
 Util functions for luigi bigmetadata tasks.
 '''
@@ -317,7 +319,7 @@ def generate_tile_summary(session, table_id, column_id, tablename, colname):
       WITH vector AS (SELECT CASE
                         WHEN ST_GeometryType({colname}) IN ('ST_Polygon', 'ST_MultiPolygon') THEN
                              ST_CollectionExtract(ST_MakeValid(
-                             ST_SimplifyVW({colname}, 0.0005)), 3)
+                             ST_SimplifyVW({colname}, 0.00001)), 3)
                           ELSE {colname}
                         END the_geom
                       FROM {tablename} vector)

--- a/tasks/util.py
+++ b/tasks/util.py
@@ -330,13 +330,13 @@ def generate_tile_summary(session, table_id, column_id, tablename, colname):
                Nullif(SUM(CASE ST_GeometryType(vector.the_geom)
                  WHEN 'ST_Point' THEN 1
                  WHEN 'ST_LineString' THEN
-                       ST_Length({st_clip}(vector.the_geom, ST_Envelope(geom))) /
+                       ST_Length(ST_MakeValid({st_clip}(vector.the_geom, ST_Envelope(geom)))) /
                        ST_Length(vector.the_geom)
                  ELSE
                    CASE WHEN ST_Within(geom, vector.the_geom) THEN
                              ST_Area(geom) / ST_Area(vector.the_geom)
                         WHEN ST_Within(vector.the_geom, geom) THEN 1
-                        ELSE ST_Area({st_clip}(vector.the_geom, ST_Envelope(geom))) /
+                        ELSE ST_Area(ST_MakeValid({st_clip}(vector.the_geom, ST_Envelope(geom)))) /
                              ST_Area(vector.the_geom)
                    END
                 END), 0)
@@ -346,7 +346,7 @@ def generate_tile_summary(session, table_id, column_id, tablename, colname):
                SUM(CASE WHEN ST_Within(geom, vector.the_geom) THEN 1
                     WHEN ST_Within(vector.the_geom, geom) THEN
                          ST_Area(vector.the_geom) / ST_Area(geom)
-                    ELSE ST_Area({st_clip}(vector.the_geom, ST_Envelope(geom))) /
+                    ELSE ST_Area(ST_MakeValid({st_clip}(vector.the_geom, ST_Envelope(geom)))) /
                          ST_Area(geom)
                END)
               )::geomval percent_fill

--- a/tasks/util.py
+++ b/tasks/util.py
@@ -328,13 +328,13 @@ def generate_tile_summary(session, table_id, column_id, tablename, colname):
                Nullif(SUM(CASE ST_GeometryType(vector.the_geom)
                  WHEN 'ST_Point' THEN 1
                  WHEN 'ST_LineString' THEN
-                       ST_Length(ST_MakeValid({st_clip}(vector.the_geom, ST_Envelope(geom)))) /
+                       ST_Length({st_clip}(vector.the_geom, ST_Envelope(geom))) /
                        ST_Length(vector.the_geom)
                  ELSE
                    CASE WHEN ST_Within(geom, vector.the_geom) THEN
                              ST_Area(geom) / ST_Area(vector.the_geom)
                         WHEN ST_Within(vector.the_geom, geom) THEN 1
-                        ELSE ST_Area(ST_MakeValid({st_clip}(vector.the_geom, ST_Envelope(geom)))) /
+                        ELSE ST_Area({st_clip}(vector.the_geom, ST_Envelope(geom))) /
                              ST_Area(vector.the_geom)
                    END
                 END), 0)
@@ -344,7 +344,7 @@ def generate_tile_summary(session, table_id, column_id, tablename, colname):
                SUM(CASE WHEN ST_Within(geom, vector.the_geom) THEN 1
                     WHEN ST_Within(vector.the_geom, geom) THEN
                          ST_Area(vector.the_geom) / ST_Area(geom)
-                    ELSE ST_Area(ST_MakeValid({st_clip}(vector.the_geom, ST_Envelope(geom)))) /
+                    ELSE ST_Area({st_clip}(vector.the_geom, ST_Envelope(geom))) /
                          ST_Area(geom)
                END)
               )::geomval percent_fill
@@ -499,11 +499,6 @@ class CartoDBTarget(Target):
         self.tablename = tablename
         self.carto_url = carto_url
         self.api_key = api_key
-        # resp = requests.get('{url}/dashboard/datasets'.format(
-        #    url=os.environ['CARTODB_URL']
-        # ), cookies={
-        #    '_cartodb_session': os.environ['CARTODB_SESSION']
-        # }).content
 
     def __str__(self):
         return self.tablename

--- a/tasks/util.py
+++ b/tasks/util.py
@@ -1,5 +1,3 @@
-201708170906
-
 '''
 Util functions for luigi bigmetadata tasks.
 '''


### PR DESCRIPTION
#244

Solves a problem calculating the percent fill value for each pixel. The algorithm was miscalculating some tiles with zero or very low coverage (see the green pixels on the sea):

![201708161716_before](https://user-images.githubusercontent.com/6155203/29373506-c85907c6-82ae-11e7-8931-a462e2c6aa14.png)

Changing the spatial relation operator from `@` to `ST_Within` solves most cases:

![201708161716_after1](https://user-images.githubusercontent.com/6155203/29373514-d110dfd8-82ae-11e7-9bc3-6946a6ef2111.png)

Regenerate the band 2 setting 1 as the minimum value to include very small geometries that would be considered spurious due to rounding (thanks to @javitonino for the idea):

![201708161716_after2](https://user-images.githubusercontent.com/6155203/29373523-d7a433ae-82ae-11e7-8ae0-d82c32685c7c.png)

Reduce the tolerance for the simplification from 0.0005 (about 50 meters) to 0.00001 (about 1 meter) to improve the percent fill calculation.

Using `ST_ClipByBox2D` instead of `ST_Intersection` doesn't seem to have any negative effect (some geometries from several resolutions have been picked for testing). The algorithm shows a performance boost when using `ST_ClipByBox2D` as expected. 

~~As the documentation for `ST_ClipByBox2D` states that _The output geometry is not guaranteed to be valid_, I have added `ST_MakeValid` to its result to increase robustness.~~ **Note:** `ST_MakeValid` checks validity using `ST_IsValid` but it can be (very) costly depending on the size (number of vertices) of the geometries.