### PR TITLE
Solving BR data downloading issues

### DIFF
--- a/tasks/br/data.py
+++ b/tasks/br/data.py
@@ -59,7 +59,6 @@ class LicenseTags(TagsTask):
         ]
 
 
-
 class DownloadData(DownloadUnzipTask):
 
     state = Parameter()
@@ -70,15 +69,17 @@ class DownloadData(DownloadUnzipTask):
         cmd += ' | '
         cmd += 'awk \'{print $9}\''
         cmd += ' | '
-        cmd += 'grep -i {state}_[0-9].*zip$'.format(state=self.state)
+        cmd += 'grep {state}_[A-Za-z_]*[0-9].*zip$'.format(state=self.state.upper())
 
         return shell(cmd)
 
     def download(self):
-        filename = self._get_filename()
-        shell('wget -O {output}.zip {url}{filename}'.format(
-            output=self.output().path, url=self.URL, filename=filename
-        ))
+        filenames = self._get_filename().splitlines()
+
+        for filename in filenames:
+            shell('wget -O {output}.zip {url}{filename}'.format(
+                output=self.output().path, url=self.URL, filename=filename
+            ))
 
 
 class ImportData(CSV2TempTableTask):

--- a/tasks/br/data.py
+++ b/tasks/br/data.py
@@ -102,7 +102,8 @@ class ImportData(CSV2TempTableTask):
         else:
             state_code = self.state.upper()
 
-        filename = '{tablename}_{state_code}.[xX][lL][sS]'.format(
+        # All files are {tablename}_{state}.xls, except Basico-MG.xls
+        filename = '{tablename}[-_]{state_code}.xls'.format(
             tablename=self.tablename,
             state_code=state_code
         )
@@ -317,10 +318,7 @@ class Censos(TableTask):
         '''
         Exclude Basico/mg, which seems to be missing
         '''
-        if self.tablename == 'Basico':
-            return [s for s in DATA_STATES if s != 'mg']
-        else:
-            return DATA_STATES
+        return DATA_STATES
 
     def requires(self):
         import_data = {}

--- a/tasks/br/data.py
+++ b/tasks/br/data.py
@@ -69,17 +69,16 @@ class DownloadData(DownloadUnzipTask):
         cmd += ' | '
         cmd += 'awk \'{print $9}\''
         cmd += ' | '
-        cmd += 'grep {state}_[A-Za-z_]*[0-9].*zip$'.format(state=self.state.upper())
+        cmd += 'grep -i ^{state}_[0-9]*\.zip$'.format(state=self.state)
 
         return shell(cmd)
 
     def download(self):
-        filenames = self._get_filename().splitlines()
+        filename = self._get_filename()
 
-        for filename in filenames:
-            shell('wget -O {output}.zip {url}{filename}'.format(
-                output=self.output().path, url=self.URL, filename=filename
-            ))
+        shell('wget -O {output}.zip {url}{filename}'.format(
+            output=self.output().path, url=self.URL, filename=filename
+        ))
 
 
 class ImportData(CSV2TempTableTask):


### PR DESCRIPTION
#252

Ignoring files matching the state in lowercase to avoid mathing files like *1_Documentacao_Agregado_dos_Setor**es**_2010_20150527.zip* when checking for **ES**. Taking into account that some states can be splitted into different files