### PR TITLE
253 uk fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,19 @@ mx-census:
 		--module tasks.mx.inegi AllCensus \
 		--parallel-scheduling --workers=8
 
+### uk
+uk-all: uk-census uk-geo
+
+uk-geo:
+	docker-compose run --rm bigmetadata luigi \
+		--module tasks.uk.cdrc CDRCMetaWrapper \
+		--parallel-scheduling --workers=8
+
+uk-census:
+	docker-compose run --rm bigmetadata luigi \
+		--module tasks.uk.ons EnglandWalesMetaWrapper \
+		--parallel-scheduling --workers=8
+
 ### us
 us-all: us-bls us-acs us-lodes us-spielman us-tiger us-enviroatlas us-huc us-dcp us-dob us-zillow
 

--- a/tasks/meta.py
+++ b/tasks/meta.py
@@ -783,6 +783,11 @@ class CurrentSession(object):
             print 'FORKED: {} not {}'.format(self._pid, os.getpid())
         if not self._session:
             self.begin()
+        try:
+            self._session.execute("SELECT 1")
+        except Exception as e:
+            self._session = None
+            self.begin()
         return self._session
 
     def commit(self):

--- a/tasks/meta.py
+++ b/tasks/meta.py
@@ -785,7 +785,7 @@ class CurrentSession(object):
             self.begin()
         try:
             self._session.execute("SELECT 1")
-        except Exception as e:
+        except:
             self._session = None
             self.begin()
         return self._session

--- a/tasks/uk/cdrc.py
+++ b/tasks/uk/cdrc.py
@@ -41,9 +41,13 @@ class DownloadOutputAreas(DownloadUnzipTask):
     URL = 'https://data.cdrc.ac.uk/dataset/68771b14-72aa-4ad7-99f3-0b8d1124cb1b/resource/8fff55da-6235-459c-b66d-017577b060d3/download/output-area-classification.zip'
 
     def download(self):
-        shell('wget --header=\'Cookie: auth_tkt="96a4778a0e3366127d4a47cf19a9c7d65751e5a9talos!userid_type:unicode"; auth_tkt="96a4778a0e3366127d4a47cf19a9c7d65751e5a9talos!userid_type:unicode";\' -O {output}.zip {url}'.format(
+        if 'CDRC_COOKIE' not in os.environ:
+            raise ValueError('This task requires a CDRC cookie. Put it in the `.env` file\n' \
+                             'e.g: CDRC_COOKIE=\'auth_tkt="00000000000000000username!userid_type:unicode"\'')
+        shell('wget --header=\'Cookie: {cookie}\' -O {output}.zip {url}'.format(
             output=self.output().path,
-            url=self.URL))
+            url=self.URL,
+            cookie=os.environ['CDRC_COOKIE']))
 
 
 class ImportOutputAreas(Shp2TempTableTask):

--- a/tasks/uk/cdrc.py
+++ b/tasks/uk/cdrc.py
@@ -42,7 +42,7 @@ class DownloadOutputAreas(DownloadUnzipTask):
 
     def download(self):
         if 'CDRC_COOKIE' not in os.environ:
-            raise ValueError('This task requires a CDRC cookie. Put it in the `.env` file\n' \
+            raise ValueError('This task requires a CDRC cookie. Put it in the `.env` file\n'
                              'e.g: CDRC_COOKIE=\'auth_tkt="00000000000000000username!userid_type:unicode"\'')
         shell('wget --header=\'Cookie: {cookie}\' -O {output}.zip {url}'.format(
             output=self.output().path,

--- a/tasks/uk/ons.py
+++ b/tasks/uk/ons.py
@@ -4,7 +4,7 @@ from luigi import Task, Parameter, LocalTarget, WrapperTask
 
 from tasks.meta import OBSColumn, DENOMINATOR, current_session, OBSTag
 from tasks.util import (TableTask, ColumnsTask, classpath, shell,
-                        DownloadUnzipTask, TagsTask, TempTableTask, MetaWrapper)
+                        DownloadUnzipTask, TagsTask, TempTableTask, MetaWrapper, create_temp_schema)
 from tasks.uk.cdrc import OutputAreaColumns, OutputAreas
 from tasks.tags import UnitTags, SectionTags, SubsectionTags, LicenseTags
 
@@ -1127,6 +1127,9 @@ class ImportAllEnglandWalesLocal(Task):
         return DownloadEnglandWalesLocal()
 
     def run(self):
+        # Create schema in this wrapper task, avoid race conditions with the dependencies
+        create_temp_schema(self)
+
         infiles = shell('ls {input}/LC*DATA.CSV'.format(
             input=self.input().path))
 

--- a/tasks/util.py
+++ b/tasks/util.py
@@ -1294,14 +1294,17 @@ class TempTableTask(Task):
 
 @TempTableTask.event_handler(Event.START)
 def clear_temp_table(task):
+    create_temp_schema(task)
     target = task.output()
-    shell("psql -c 'CREATE SCHEMA IF NOT EXISTS \"{schema}\"'".format(
-        schema=classpath(task)))
     if task.force or target.empty():
         session = current_session()
         session.execute('DROP TABLE IF EXISTS "{schema}".{tablename}'.format(
             schema=classpath(task), tablename=task.task_id))
         session.flush()
+
+
+def create_temp_schema(task):
+    shell("psql -c 'CREATE SCHEMA IF NOT EXISTS \"{schema}\"'".format(schema=classpath(task)))
 
 
 class GdbFeatureClass2TempTableTask(TempTableTask):


### PR DESCRIPTION
#253 fixes, no improvements since this was getting quite big.

Highlights:
- ONS download was broken. There is an archived version, but the archive servers are very slow (20kb/s). I found an alternative source that has the same data, but with two levels of zips. I updated the task to handle that.
- CDRC download requires a login, and talos's cookie was outdated. I added an env variable to specify the cookie instead of hardcoding it.
- I also made the `ImportAllEnglandWalesLocal` task parallelizable. Before it returned subtasks one by one. Now it returns them all at once, so Luigi can schedule parallel execution of them
- Finally, a fix to some DB connection pooling problems. The problem is still there, I did not find a good solution to it after a few hours. So I just added a connectivity check before using a connection.
- Makefile targets