### PR TITLE
Use curl instead of wget for ftp download

### DIFF
--- a/tasks/us/epa/huc.py
+++ b/tasks/us/epa/huc.py
@@ -13,7 +13,7 @@ class DownloadHUC(DownloadUnzipTask):
     URL = 'ftp://newftp.epa.gov/epadatacommons/ORD/EnviroAtlas/NHDPlusV2_WBDSnapshot_EnviroAtlas_CONUS.gdb.zip'
 
     def download(self):
-        shell('wget -O "{output}".zip "{url}"'.format(
+        shell('curl -o "{output}".zip "{url}"'.format(
             url=self.URL,
             output=self.output().path
         ))


### PR DESCRIPTION
Fixes #279 

Details on why this change works -> https://github.com/CartoDB/bigmetadata/issues/279#issuecomment-326334827
This is more proof that we should approach #255 at some point.

Tested in ETL and seems to be working.