### PR TITLE
Install mapshaper in the bigmetadata Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get -yq remove python-pip && apt-get clean
 RUN easy_install pip
 RUN pip install --upgrade -r /bigmetadata/requirements.txt
 
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install nodejs
+RUN npm install -g mapshaper
+
 EXPOSE 8082
 
 WORKDIR /bigmetadata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,10 @@
     "links": [
       "redis:localhost"
     ],
-    "privileged": true
+    "privileged": true,
+    "ports": [
+      "5554:5432" 
+    ]
   },
   "nginx": {
     "image": "nginx:latest",


### PR DESCRIPTION
- Install nodejs (v6.11.3 LTS) and npm in the bigmetadata Docker image
- Install mapshaper in the bigmetadata Docker image
- Expose Docker machine port 5432 as port 5554 in the host machine

Closes #318