### PR TITLE
Friday leapfrogging

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,12 @@ See [QUICKSTART](docs/source/quickstart.rst).
 Most of the common tasks have already been wrapped up in the `Makefile`:
 
 * `make catalog`: Regenerate the catalog
-* `make pdf-catalog`: Regenerate the PDF version of the catalog
-* `make deploy-catalog`: Deploy the catalog to Github Pages. This will also
-  rebuild both the HTML and PDF catalogs
+* `make deploy-html-catalog`: Deploy the catalog to Github Pages
 * `make sh`: Drop into the bigmetadata container to run shell scripts
 * `make python`: Drop into an interactive Python shell in the bigmetadata
   container
 * `make psql`: Drop into an interactive psql session in the bigmetadata
   container's database
-* `make sync`: Sync local data and metadata to the Observatory account.
 
 The ETL tasks have also already been wrapped up in the Makefile:
 

--- a/tasks/sphinx.py
+++ b/tasks/sphinx.py
@@ -69,8 +69,8 @@ class GenerateRST(Task):
             REPLACE(MAX(section), 'section/', '') section,
             REPLACE(MAX(subsection), 'subsection/', '') subsection
             FROM subquery GROUP BY geom_id)
-          SELECT DISTINCT UNNEST(section_tags), UNNEST(subsection_tags)
-          FROM observatory.obs_meta
+          SELECT DISTINCT UNNEST(section_tags), unnested.subsection_tags
+          FROM observatory.obs_meta, LATERAL (SELECT UNNEST(subsection_tags) AS subsection_tags) unnested
           UNION ALL
           SELECT DISTINCT section, subsection
           FROM subquery2


### PR DESCRIPTION
In this PR there are two changes.

UNNEST
------
The first one is related to an issue with postgresql 10, which is also not great in psql 9.5 and 9.6. Basically, we use a double `unnest` during catalog generation to extract the section/subsection tags. The behaviour psql has here is strange, and varies between versions. In pseudo-SQL.

PSQL 9.6. It takes the minimum common multiple and repeats. Not the cross-product!
```SELECT UNNEST(1,2,3,4), UNNEST (a,b)
1 a
2 b
3 a
4 b
```

PSQL 10. Puts the two series together, fills with NULLs
```SELECT UNNEST(1,2,3,4), UNNEST (a,b)
1 a
2 b
3 NULL
4 NULL
```

In the code, we assume the cross-product. This is fine in PSQL 9.5/9.6 in the case where one of the unnest has only one element (which is the case for most datasets). So it kind of works currently, but by chance. The proposed change should be compatible and correct with any version.

Makefile
-------

Had some fun refactoring the Makefile. Mainly, it removed unused targets, extracts common behaviour when possible, and adds the possibility to run in a virtualenv for the `run` tasks.