### PR TITLE
Create obs table to table

### DIFF
--- a/tasks/base_tasks.py
+++ b/tasks/base_tasks.py
@@ -774,7 +774,7 @@ class TableTask(Task):
         return None
 
     def targets(self):
-        return []
+        return {}
 
     def timespan(self):
         '''

--- a/tasks/base_tasks.py
+++ b/tasks/base_tasks.py
@@ -773,6 +773,9 @@ class TableTask(Task):
         '''
         return None
 
+    def targets(self):
+        return []
+
     def timespan(self):
         '''
         Must return an arbitrary string timespan (for example, ``2014``, or
@@ -939,7 +942,8 @@ class TableTask(Task):
                          underscore_slugify(unqualified_task_id(self.task_id)),
                          OBSTable(description=self.description(),
                                   version=self.version(),
-                                  timespan=self.timespan()),
+                                  timespan=self.timespan(),
+                                  targets=self.targets()),
                          self._columns, self)
         return tt
 

--- a/tasks/meta.py
+++ b/tasks/meta.py
@@ -248,7 +248,7 @@ def tag_creator(tagtarget):
     return coltag
 
 
-def columntargets_creator(coltarget_or_col, reltype):
+def coltocoltargets_creator(coltarget_or_col, reltype):
     # we should never see these committed, they are a side effect of output()
     # being run before parent tasks can generate requirements
     # they would violate constraints
@@ -263,7 +263,7 @@ def columntargets_creator(coltarget_or_col, reltype):
     return OBSColumnToColumn(target=col, reltype=reltype)
 
 
-def tabletargets_creator(target, reltype):
+def tabletotabletargets_creator(target, reltype):
     return OBSTableToTable(target=target, reltype=reltype)
 
 
@@ -452,7 +452,7 @@ class OBSColumn(Base):
     tables = relationship("OBSColumnTable", back_populates="column", cascade="all,delete")
     tags = association_proxy('column_column_tags', 'tag', creator=tag_creator)
 
-    targets = association_proxy('tgts', 'reltype', creator=columntargets_creator)
+    targets = association_proxy('tgts', 'reltype', creator=coltocoltargets_creator)
 
     version = Column(Numeric, default=0, nullable=False)
     extra = Column(JSON)
@@ -638,7 +638,7 @@ class OBSTable(Base):
     the_geom = Column(Geometry)
     description = Column(Text)
 
-    targets = association_proxy('tgts', 'reltype', creator=tabletargets_creator)
+    targets = association_proxy('tgts', 'reltype', creator=tabletotabletargets_creator)
 
     version = Column(Numeric, default=0, nullable=False)
 

--- a/tasks/meta.py
+++ b/tasks/meta.py
@@ -269,6 +269,11 @@ def targets_creator(coltarget_or_col, reltype):
     return OBSColumnToColumn(target=col, reltype=reltype)
 
 
+table_to_table = Table("obs_table_to_table", Base.metadata,
+                       Column("source_id", Text, ForeignKey("obs_table.id"), primary_key=True),
+                       Column("target_id", Text, ForeignKey("obs_table.id"), primary_key=True))
+
+
 class OBSColumnToColumn(Base):
     '''
     Relates one column to another.  For example, a ``Text`` column may contain
@@ -319,7 +324,6 @@ class OBSColumnToColumn(Base):
                               cascade="all, delete-orphan",
                           ))
     target = relationship('OBSColumn', foreign_keys=[target_id])
-
 
 
 # For example, a single census identifier like b01001001
@@ -594,6 +598,12 @@ class OBSTable(Base):
     timespan = Column(Text)
     the_geom = Column(Geometry)
     description = Column(Text)
+
+    targets = relationship("OBSTable",
+                           secondary=table_to_table,
+                           primaryjoin=id==table_to_table.c.source_id,
+                           secondaryjoin=id==table_to_table.c.target_id,
+                           backref="sources")
 
     version = Column(Numeric, default=0, nullable=False)
 

--- a/tasks/targets.py
+++ b/tasks/targets.py
@@ -219,10 +219,10 @@ class TableTarget(Target):
         obs_table.tablename = '{prefix}{name}'.format(prefix=OBSERVATORY_PREFIX, name=sha1(
             underscore_slugify(self._id).encode('utf-8')).hexdigest())
         self.table = '{schema}.{table}'.format(schema=OBSERVATORY_SCHEMA, table=obs_table.tablename)
+        self.obs_table = obs_table
         self._tablename = obs_table.tablename
         self._schema = schema
         self._name = name
-        self._obs_table = obs_table
         self._obs_dict = obs_table.__dict__.copy()
         self._columns = columns
         self._task = task
@@ -244,7 +244,7 @@ class TableTarget(Target):
         '''
         session = current_session()
         existing = self.get(session)
-        new_version = float(self._obs_table.version or 0.0)
+        new_version = float(self.obs_table.version or 0.0)
         if existing:
             existing_version = float(existing.version or 0.0)
             if existing in session:
@@ -308,7 +308,7 @@ class TableTarget(Target):
                 coltype = getattr(types, col.type.capitalize())
             columns.append(Column(colname, coltype))
 
-        obs_table = self.get(session) or self._obs_table
+        obs_table = self.get(session) or self.obs_table
         # replace local data table
         if obs_table.id in metadata.tables:
             metadata.tables[obs_table.id].drop()
@@ -322,8 +322,8 @@ class TableTarget(Target):
         session = current_session()
 
         # replace metadata table
-        self._obs_table = session.merge(self._obs_table)
-        obs_table = self._obs_table
+        self.obs_table = session.merge(self.obs_table)
+        obs_table = self.obs_table
 
         for i, colname_coltarget in enumerate(self._columns.items()):
             colname, coltarget = colname_coltarget


### PR DESCRIPTION
Creates the `observatory.OBS_Table_To_Table` table. To use it in a `TableTask`:
```
def targets(self):
    return {self.input()['geo'].obs_table: GEOM_REF}
```
Closes #385