### PR TITLE
Add Canadian Dissemination Areas

### DIFF
--- a/tasks/ca/statcan/census_columns.json
+++ b/tasks/ca/statcan/census_columns.json
@@ -1,0 +1,29 @@
+{
+	"t010c002_t": {
+		"exceptions": [
+			{
+				"resolution": "da_",
+				"survey": "census",
+				"topic": "t010"
+			}
+		]
+    },
+    "t010c003_t": {
+		"exceptions": [
+			{
+				"resolution": "da_",
+				"survey": "census",
+				"topic": "t010"
+			}
+		]
+    },
+    "t010c006_t": {
+		"exceptions": [
+			{
+				"resolution": "da_",
+				"survey": "census",
+				"topic": "t010"
+			}
+		]
+    }
+}

--- a/tasks/ca/statcan/cols_census.py
+++ b/tasks/ca/statcan/cols_census.py
@@ -1,12 +1,19 @@
+import os
+from luigi import Parameter
+
 from tasks.meta import OBSColumn, DENOMINATOR, UNIVERSE
 from tasks.base_tasks import ColumnsTask
 from tasks.tags import SectionTags, SubsectionTags, UnitTags, PublicTags
 from tasks.ca.statcan.license import LicenseTags, SourceTags
 
 from collections import OrderedDict
+from lib.columns import ColumnsDeclarations
 
 
 class CensusColumns(ColumnsTask):
+    resolution = Parameter()
+    survey = Parameter()
+    topic=Parameter()
 
     def requires(self):
         return {
@@ -11209,7 +11216,7 @@ class CensusColumns(ColumnsTask):
             tags=[ca, subsections['segments']],
             targets={},)
 
-        cols = OrderedDict([
+        allcols = OrderedDict([
             ('t001c001_t', t001c001_t),
             ('t001c001_m', t001c001_m),
             ('t001c001_f', t001c001_f),
@@ -12453,6 +12460,12 @@ class CensusColumns(ColumnsTask):
             ('t010c006_t', t010c006_t),
             ('t010c007_t', t010c007_t),
         ])
+
+        columnsFilter = ColumnsDeclarations(os.path.join(os.path.dirname(__file__), 'census_columns.json'))
+        parameters = '{{"resolution":"{resolution}","survey":"{survey}", "topic":"{topic}"}}'.format(
+                        resolution=self.resolution, survey=self.survey, topic=self.topic)
+        cols = columnsFilter.filter_columns(allcols, parameters)
+
         for colname, col in cols.items():
             col.tags.append(license)
             col.tags.append(source)

--- a/tasks/ca/statcan/cols_census.py
+++ b/tasks/ca/statcan/cols_census.py
@@ -13,7 +13,7 @@ from lib.columns import ColumnsDeclarations
 class CensusColumns(ColumnsTask):
     resolution = Parameter()
     survey = Parameter()
-    topic=Parameter()
+    topic = Parameter()
 
     def requires(self):
         return {

--- a/tasks/ca/statcan/data.py
+++ b/tasks/ca/statcan/data.py
@@ -62,7 +62,8 @@ class SplitAndTransposeData(BaseParams, Task):
             GEO_PR: None,
             GEO_CD: None,
             GEO_CSD: None,
-            GEO_CMA: ('cmaca_name', (r'part\)$',))
+            GEO_CMA: ('cmaca_name', (r'part\)$',)),
+            GEO_DA: None,
         },
         SURVEY_NHS: {
             GEO_CT: None,
@@ -253,7 +254,7 @@ class AllCensusTopics(BaseParams, WrapperTask):
     def requires(self):
         topic_range = list(range(1, 11))   # 1-10
 
-        for resolution in (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA):
+        for resolution in (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA, GEO_DA):
             for count in topic_range:
                 topic = 't{:03d}'.format(count)
                 yield Census(resolution=resolution, survey=SURVEY_CEN, topic=topic)
@@ -289,7 +290,7 @@ class CensusMetaWrapper(MetaWrapper):
 
     params = {
         'topic': ['t{:03d}'.format(i) for i in range(1,11)],
-        'resolution': (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA)
+        'resolution': (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA, GEO_DA)
     }
 
     def tables(self):

--- a/tasks/ca/statcan/data.py
+++ b/tasks/ca/statcan/data.py
@@ -253,7 +253,7 @@ class AllCensusTopics(BaseParams, WrapperTask):
     def requires(self):
         topic_range = list(range(1, 11))   # 1-10
 
-        for resolution in (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA, GEO_DA):
+        for resolution in (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA):
             for count in topic_range:
                 topic = 't{:03d}'.format(count)
                 yield Census(resolution=resolution, survey=SURVEY_CEN, topic=topic)
@@ -289,7 +289,7 @@ class CensusMetaWrapper(MetaWrapper):
 
     params = {
         'topic': ['t{:03d}'.format(i) for i in range(1,11)],
-        'resolution': (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA, GEO_DA)
+        'resolution': (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA)
     }
 
     def tables(self):

--- a/tasks/ca/statcan/data.py
+++ b/tasks/ca/statcan/data.py
@@ -243,7 +243,7 @@ class Census(Survey):
             'data': CopyDataToTable(resolution=self.resolution, survey=SURVEY_CEN, topic=self.topic),
             'geo': Geography(resolution=self.resolution),
             'geometa': GeographyColumns(resolution=self.resolution),
-            'meta': CensusColumns(),
+            'meta': CensusColumns(resolution=self.resolution, survey=self.survey, topic=self.topic),
         }
 
     def timespan(self):

--- a/tasks/ca/statcan/data.py
+++ b/tasks/ca/statcan/data.py
@@ -10,7 +10,7 @@ from tasks.base_tasks import DownloadUnzipTask, TableTask, TempTableTask, MetaWr
 from tasks.util import shell, classpath
 from tasks.meta import current_session
 from tasks.ca.statcan.geo import (
-    GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA,
+    GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA, GEO_DA,
     GEOGRAPHY_CODES, GEOGRAPHIES, GeographyColumns, Geography)
 from tasks.ca.statcan.util import StatCanParser
 from tasks.ca.statcan.cols_census import CensusColumns
@@ -38,7 +38,6 @@ SURVEY_URLS = {
 }
 
 URL = 'http://www12.statcan.gc.ca/{survey_url}/2011/dp-pd/prof/details/download-telecharger/comprehensive/comp_download.cfm?CTLG={survey_code}&FMT=CSV{geo_code}'
-
 
 class BaseParams(metaclass=ABCMeta):
     resolution = Parameter(default=GEO_PR)
@@ -254,7 +253,7 @@ class AllCensusTopics(BaseParams, WrapperTask):
     def requires(self):
         topic_range = list(range(1, 11))   # 1-10
 
-        for resolution in (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA):
+        for resolution in (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA, GEO_DA):
             for count in topic_range:
                 topic = 't{:03d}'.format(count)
                 yield Census(resolution=resolution, survey=SURVEY_CEN, topic=topic)
@@ -290,7 +289,7 @@ class CensusMetaWrapper(MetaWrapper):
 
     params = {
         'topic': ['t{:03d}'.format(i) for i in range(1,11)],
-        'resolution': (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA)
+        'resolution': (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA, GEO_DA)
     }
 
     def tables(self):
@@ -303,7 +302,7 @@ class NHSMetaWrapper(MetaWrapper):
 
     params = {
         'topic': ['t{:03d}'.format(i) for i in range(1,30)],
-        'resolution': (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA)
+        'resolution': (GEO_CT, GEO_PR, GEO_CD, GEO_CSD, GEO_CMA) # NHS not available at Dissemination Area level
     }
 
     def tables(self):

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -13,6 +13,7 @@ GEO_PR = 'pr_'
 GEO_CD = 'cd_'
 GEO_CSD = 'csd'
 GEO_CMA = 'cma'
+GEO_DA = 'da'
 
 GEOGRAPHIES = (
     GEO_CT,
@@ -20,6 +21,7 @@ GEOGRAPHIES = (
     GEO_CD,
     GEO_CSD,
     GEO_CMA,
+    GEO_DA,
 )
 
 
@@ -29,6 +31,7 @@ GEOGRAPHY_NAMES = {
     GEO_CD: 'Census divisions',
     GEO_CSD: 'Census subdivisions',
     GEO_CMA: 'Census metropolitan areas and census agglomerations',
+    GEO_DA: 'Census dissemination areas',
 }
 
 GEOGRAPHY_DESCS = {
@@ -37,6 +40,7 @@ GEOGRAPHY_DESCS = {
     GEO_CD: '',
     GEO_CSD: '',
     GEO_CMA: '',
+    GEO_DA: '',
 }
 
 GEOGRAPHY_PROPERNAMES = {
@@ -45,6 +49,7 @@ GEOGRAPHY_PROPERNAMES = {
     GEO_CD: 'CDNAME',
     GEO_CSD: 'CSDNAME',
     GEO_CMA: 'CMANAME',
+    GEO_DA: 'DAUID' # DA has no proper name
 }
 
 GEOGRAPHY_CODES = {
@@ -53,14 +58,17 @@ GEOGRAPHY_CODES = {
     GEO_CD: 701,
     GEO_CSD: 301,
     GEO_CMA: 201,
+    GEO_DA: 1501,
 }
 
 GEOGRAPHY_TAGS = {
-    GEO_CT: ['cartographic_boundary', 'interpolation_boundary'],
+    GEO_CT: ['cartographic_boundary'],
     GEO_PR: ['cartographic_boundary', 'interpolation_boundary'],
     GEO_CD: ['cartographic_boundary', 'interpolation_boundary'],
     GEO_CSD: ['cartographic_boundary', 'interpolation_boundary'],
-    GEO_CMA: ['cartographic_boundary', 'interpolation_boundary']
+    GEO_CMA: ['cartographic_boundary'],
+    GEO_DA: ['cartographic_boundary', 'interpolation_boundary']
+
 }
 
 
@@ -69,12 +77,13 @@ GEOGRAPHY_TAGS = {
 class DownloadGeography(DownloadUnzipTask):
 
     resolution = Parameter(default=GEO_PR)
+    year = Parameter(default=2011)
 
-    URL = 'http://www12.statcan.gc.ca/census-recensement/2011/geo/bound-limit/files-fichiers/g{resolution}000b11a_e.zip'
+    URL = 'http://www12.statcan.gc.ca/census-recensement/{year}/geo/bound-limit/files-fichiers/g{resolution}_000b11a_e.zip'
 
     def download(self):
         shell('wget -O {output}.zip {url}'.format(
-            output=self.output().path, url=self.URL.format(resolution=self.resolution)
+            output=self.output().path, url=self.URL.format(year=self.year, resolution=self.resolution)
         ))
 
 
@@ -113,6 +122,7 @@ class GeographyColumns(ColumnsTask):
         GEO_CMA: 3,
         GEO_CSD: 4,
         GEO_CT: 5,
+        GEO_DA: 6,
     }
 
     def version(self):

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -26,7 +26,7 @@ GEOGRAPHIES = (
 
 
 GEOGRAPHY_NAMES = {
-    GEO_CT: 'Census Tracts',
+    GEO_CT: 'Census tracts',
     GEO_PR: 'Canada, provinces and territories',
     GEO_CD: 'Census divisions',
     GEO_CSD: 'Census subdivisions',

--- a/tasks/ca/statcan/geo.py
+++ b/tasks/ca/statcan/geo.py
@@ -13,7 +13,7 @@ GEO_PR = 'pr_'
 GEO_CD = 'cd_'
 GEO_CSD = 'csd'
 GEO_CMA = 'cma'
-GEO_DA = 'da'
+GEO_DA = 'da_'
 
 GEOGRAPHIES = (
     GEO_CT,
@@ -79,7 +79,7 @@ class DownloadGeography(DownloadUnzipTask):
     resolution = Parameter(default=GEO_PR)
     year = Parameter(default=2011)
 
-    URL = 'http://www12.statcan.gc.ca/census-recensement/{year}/geo/bound-limit/files-fichiers/g{resolution}_000b11a_e.zip'
+    URL = 'http://www12.statcan.gc.ca/census-recensement/{year}/geo/bound-limit/files-fichiers/g{resolution}000b11a_e.zip'
 
     def download(self):
         shell('wget -O {output}.zip {url}'.format(

--- a/tasks/simplifications.json
+++ b/tasks/simplifications.json
@@ -155,7 +155,7 @@
 
 	"CA": "-------------------------------------",
 
-	".importgeography_cd_": {
+	"ca.statcan.geo.importgeography_cd_": {
 		"simplification": "mapshaper",
 		"geomfield": "wkb_geometry",
 		"factor": "13.5",
@@ -190,7 +190,6 @@
 		"maxmemory": "8192",
 		"skipfailures": "no"
 	},
-
 	"ca.statcan.geo.importgeography_da_": {
 		"simplification": "mapshaper",
 		"geomfield": "wkb_geometry",

--- a/tasks/simplifications.json
+++ b/tasks/simplifications.json
@@ -155,7 +155,7 @@
 
 	"CA": "-------------------------------------",
 
-	"ca.statcan.geo.importgeography_cd_": {
+	".importgeography_cd_": {
 		"simplification": "mapshaper",
 		"geomfield": "wkb_geometry",
 		"factor": "13.5",
@@ -191,7 +191,7 @@
 		"skipfailures": "no"
 	},
 
-	"ca.statcan.geo.importgeography_da": {
+	"ca.statcan.geo.importgeography_da_": {
 		"simplification": "mapshaper",
 		"geomfield": "wkb_geometry",
 		"factor": "7",

--- a/tasks/simplifications.json
+++ b/tasks/simplifications.json
@@ -191,6 +191,14 @@
 		"skipfailures": "no"
 	},
 
+	"ca.statcan.geo.importgeography_da": {
+		"simplification": "mapshaper",
+		"geomfield": "wkb_geometry",
+		"factor": "7",
+		"maxmemory": "8192",
+		"skipfailures": "no"
+	},
+
 	"ES": "-------------------------------------",
 
 	"es.cnig.importgeometry_x_ccaa_20150101": {


### PR DESCRIPTION
This PR brings in the geometries and data for 2011 Canadian dissemination areas, the smallest standard geographic area for which all census data are disseminated.

Things that need testing/fixing:
- Parameters in`simplifications.json`. I'm not familiar with the new work on geometry simplification, so I just used the same parameters as Canadian census tracts. I checked the shapefile produced and it looked okay, but more testing and fixing might be needed. The size of the shapefile went from 201 MB to 101.6 MB.

- Dissemination areas do not have a proper name, so I used the same value as the geom_ref (`DAUID`) for now. Do we have a way to handle no-name geometries? If not, I can just change the ColumnsTask and TableTask to not create or populate a `geom_name` if the `self.resolution` is dissemination area.

- The raw download of data for dissemination areas comes in 13 files (for each province of Canada) with names like "98-316-XWE2011001-1501-ALTA.csv" and "98-316-XWE2011001-1501-BC.csv". I don't think this should be a problem with how `SplitAndTransposeData` and `StatCanParser` work, but just something to keep in mind.

Finally, I ran a sample on one topic (t001) locally with the following commands:

```
docker-compose run --rm bigmetadata luigi --parallel-scheduling --workers=8 --module tasks.ca.statcan.data tasks.ca.statcan.data.Census --resolution da --survey census --topic t001
```
And then checked that the count of the geometry table and the data table matched the expected amount (56,204 dissemination areas in Canada).

And then checked a local version of the catalog with:

```
make run sphinx.Catalog
docker-compose up -d nginx
``` 

It looks okay so far, but now I need more help with testing and review!

Fixes: https://github.com/CartoDB/bigmetadata/issues/377