### PR TITLE
Migrate docker compose to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ For example, to run QCEW numbers for one quarter:
 
     make -- run us.bls QCEW --year 2014 --qtr 4
 
+### Setting up local directories
+
+`docker-compose.yml` allows configuring two environment variables:
+- `DO_LOCAL_POSTGRESQL_LIB_DIR` (default: `./postgres/data`).
+- `DO_LOCAL_POSTGRESQL_TMP_DIR` (default: `./tmp`).
+
+That's useful if you have an external HD for storing DO.
+
 ### Naming conventions
 
 #### Tables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./dataservices-api:/dataservices-api
       - ./data-services:/data-services
       - ./cartodb-postgresql:/cartodb-postgresql
-      - ${LOCAL_POSTGESQL_TMP_DIR:-./tmp}:/bigmetadata/tmp
+      - ${LOCAL_POSTGRESQL_TMP_DIR:-./tmp}:/bigmetadata/tmp
     environment:
       PGUSER: docker
       PGPASSWORD: docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,83 +1,71 @@
-{
-  "postgres": {
-    "image": "carto/bigmetadata_postgres",
-    "volumes": [
-      "./postgres/data:/var/lib/postgresql",
-      "./observatory-extension:/observatory-extension",
-      "./dataservices-api:/dataservices-api",
-      "./data-services:/data-services",
-      "./cartodb-postgresql:/cartodb-postgresql",
-      "./tmp:/bigmetadata/tmp"
-    ],
-    "environment": {
-      "PGUSER": "docker",
-      "PGPASSWORD": "docker",
-      "PGDATABASE": "gis",
-      "LC_ALL": "C.UTF-8",
-      "LANG": "C.UTF-8"
-    },
-    "privileged": true,
-    "ports": [
-      "5554:5432"
-    ]
-  },
-  "nginx": {
-    "image": "nginx:latest",
-    "volumes": [
-      "./conf/nginx.conf:/etc/nginx/conf.d/default.conf:ro",
-      "./catalog/build/html:/usr/share/nginx/html/catalog/:ro",
-      "./docs/build/html:/usr/share/nginx/html/docs/:ro",
-      "./perftest:/usr/share/nginx/html/perftest/:ro",
-    ],
-    "ports": [
-       "80"
-    ],
-  },
-  "bigmetadata_daemon": {
-    "image": "carto/bigmetadata",
-    "links": [
-      "postgres"
-    ],
-    "volumes": [
-      ".:/bigmetadata",
-    ],
-    "ports": [
-      "8082"
-    ],
-    "environment": {
-      "PYTHONPATH": "/bigmetadata",
-      "PGHOST": "postgres",
-      "PGUSER": "docker",
-      "PGPASSWORD": "docker",
-      "PGDATABASE": "gis",
-      "LC_ALL": "C.UTF-8",
-      "LANG": "C.UTF-8",
-      "LUIGI_CONFIG_PATH": "/bigmetadata/conf/luigi_daemon.cfg",
-    },
-    "env_file": ".env",
-    "command": "/bin/bash -c 'while : ; do pg_isready -t 1 && break; done && luigid'"
-  },
-  "bigmetadata": {
-    "image": "carto/bigmetadata",
-    "links": [
-      "postgres",
-      "bigmetadata_daemon",
-    ],
-    "volumes": [
-      ".:/bigmetadata"
-    ],
-    "environment": {
-      "PYTHONPATH": "/bigmetadata",
-      "PGHOST": "postgres",
-      "PGUSER": "docker",
-      "PGPASSWORD": "docker",
-      "PGDATABASE": "gis",
-      "LC_ALL": "C.UTF-8",
-      "LANG": "C.UTF-8",
-      "LUIGI_CONFIG_PATH": "/bigmetadata/conf/luigi_client.cfg",
-    },
-    "env_file": ".env",
-    "stdin_open": true,
-    "tty": true
-  }
-}
+version: '3.1'
+services:
+  postgres:
+    image: carto/bigmetadata_postgres
+    volumes:
+      - ${LOCAL_POSTGRESQL_LIB_DIR:-./postgres/data}:/var/lib/postgresql
+      - ./observatory-extension:/observatory-extension
+      - ./dataservices-api:/dataservices-api
+      - ./data-services:/data-services
+      - ./cartodb-postgresql:/cartodb-postgresql
+      - ${LOCAL_TMP_DIR:-./tmp}:/bigmetadata/tmp
+    environment:
+      PGUSER: docker
+      PGPASSWORD: docker
+      PGDATABASE: gis
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+    privileged: true
+    ports:
+      - "5554:5432"
+    env_file: .env
+
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./conf/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./catalog/build/html:/usr/share/nginx/html/catalog/:ro
+      - ./docs/build/html:/usr/share/nginx/html/docs/:ro
+      - ./perftest:/usr/share/nginx/html/perftest/:ro
+    ports:
+      - 80
+
+  bigmetadata_daemon:
+    image: carto/bigmetadata
+    links:
+      - postgres
+    volumes:
+      - .:/bigmetadata
+    ports:
+      - 8082
+    environment:
+      PYTHONPATH: /bigmetadata
+      PGHOST: postgres
+      PGUSER: docker
+      PGPASSWORD: docker
+      PGDATABASE: gis
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+      LUIGI_CONFIG_PATH: /bigmetadata/conf/luigi_daemon.cfg
+    env_file: .env
+    command: "/bin/bash -c 'while : ; do pg_isready -t 1 && break; done && luigid'"
+
+  bigmetadata:
+    image: carto/bigmetadata
+    links:
+      - postgres
+      - bigmetadata_daemon
+    volumes:
+      - .:/bigmetadata
+    environment:
+      PYTHONPATH: /bigmetadata
+      PGHOST: postgres
+      PGUSER: docker
+      PGPASSWORD: docker
+      PGDATABASE: gis
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+      LUIGI_CONFIG_PATH: /bigmetadata/conf/luigi_client.cfg
+    env_file: .env
+    stdin_open: true
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ services:
   postgres:
     image: carto/bigmetadata_postgres
     volumes:
-      - ${LOCAL_POSTGRESQL_LIB_DIR:-./postgres/data}:/var/lib/postgresql
+      - ${DO_LOCAL_POSTGRESQL_LIB_DIR:-./postgres/data}:/var/lib/postgresql
       - ./observatory-extension:/observatory-extension
       - ./dataservices-api:/dataservices-api
       - ./data-services:/data-services
       - ./cartodb-postgresql:/cartodb-postgresql
-      - ${LOCAL_POSTGRESQL_TMP_DIR:-./tmp}:/bigmetadata/tmp
+      - ${DO_LOCAL_POSTGRESQL_TMP_DIR:-./tmp}:/bigmetadata/tmp
     environment:
       PGUSER: docker
       PGPASSWORD: docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./dataservices-api:/dataservices-api
       - ./data-services:/data-services
       - ./cartodb-postgresql:/cartodb-postgresql
-      - ${LOCAL_TMP_DIR:-./tmp}:/bigmetadata/tmp
+      - ${LOCAL_POSTGESQL_TMP_DIR:-./tmp}:/bigmetadata/tmp
     environment:
       PGUSER: docker
       PGPASSWORD: docker
@@ -17,8 +17,9 @@ services:
       LANG: C.UTF-8
     privileged: true
     ports:
-      - "5554:5432"
+      - 5554:5432
     env_file: .env
+    network_mode: bridge
 
   nginx:
     image: nginx:latest
@@ -29,6 +30,7 @@ services:
       - ./perftest:/usr/share/nginx/html/perftest/:ro
     ports:
       - 80
+    network_mode: bridge
 
   bigmetadata_daemon:
     image: carto/bigmetadata
@@ -49,6 +51,7 @@ services:
       LUIGI_CONFIG_PATH: /bigmetadata/conf/luigi_daemon.cfg
     env_file: .env
     command: "/bin/bash -c 'while : ; do pg_isready -t 1 && break; done && luigid'"
+    network_mode: bridge
 
   bigmetadata:
     image: carto/bigmetadata
@@ -69,3 +72,4 @@ services:
     env_file: .env
     stdin_open: true
     tty: true
+    network_mode: bridge

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -8,7 +8,7 @@ You'll need:
 
 * `git <https://git-scm.com/>`_
 * `docker <https://www.docker.com>`_ 1.13.1+
-* `docker-compose <https://docs.docker.com/compose/>`_ 1.17.0+
+* `docker-compose <https://docs.docker.com/compose/>`_ 1.18.0+
 
 You should also install `make <https://www.gnu.org/software/make/>`_ to
 get access to convenience commands, if you don't have it already.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -7,8 +7,8 @@ Requirements
 You'll need:
 
 * `git <https://git-scm.com/>`_
-* `docker <https://www.docker.com>`_
-* `docker-compose <https://docs.docker.com/compose/>`_
+* `docker <https://www.docker.com>`_ 1.13.1+
+* `docker-compose <https://docs.docker.com/compose/>`_ 1.17.0+
 
 You should also install `make <https://www.gnu.org/software/make/>`_ to
 get access to convenience commands, if you don't have it already.


### PR DESCRIPTION
This gives us the possibility to interpolate ENV variables in order
to have more dynamic volume names.

If you add that variables to the `.env` file is going to used that ones to define the volume's path if not is going to use the default ones