### PR TITLE
Workaround brazil SaoPaulo Domicilio02 table having wrong IDs

### DIFF
--- a/tasks/br/data.py
+++ b/tasks/br/data.py
@@ -103,14 +103,17 @@ class ImportData(CSV2TempTableTask):
 
         # The provided CSV files are not well-formed, so we convert the provided XLS files into CSV
         # All files are {tablename}_{state}.xls (or XLS), except Basico-MG.xls
-        filename = '{tablename}[-_]{state_code}.[xX][lL][sS]'.format(tablename=self.tablename,
-                                                                     state_code=state_code)
-
-        path = glob.glob(os.path.join(self.input().path, '**', filename), recursive=True)[0]
-
-        df = pd.read_excel(path)
+        df = pd.read_excel(self._datafile_path(self.tablename, state_code))
         if self.tablename != 'Basico':
             df = df.apply(pd.to_numeric, errors="coerce")
+
+        # In the 20180416 version, SP_Capital-Domicilio02 files have wrong IDs (all have been rounded to 55031E+14)
+        # But the order of sectors is constant in all files of the same state, so we copy them from a different file
+        # This used to be correct in 2017's version of the file
+        if self.state.lower() == 'sp_capital' and self.tablename == 'Domicilio02':
+            domicilio01 = pd.read_excel(self._datafile_path('Domicilio01', state_code))
+            df['Cod_setor'] = domicilio01['Cod_setor']
+
         df.to_csv(os.path.join(self.input().path, '{tablename}_{state_code}.csv'.format(tablename=self.tablename,
                                                                                         state_code=state_code)),
                   index=False,
@@ -119,7 +122,11 @@ class ImportData(CSV2TempTableTask):
 
         return os.path.join(self.input().path, '{tablename}_{state_code}.csv'.format(tablename=self.tablename,
                                                                                      state_code=state_code))
+    def _datafile_path(self, tablename, state_code):
+        filename = '{tablename}[-_]{state_code}.[xX][lL][sS]'.format(tablename=tablename,
+                                                                     state_code=state_code)
 
+        return glob.glob(os.path.join(self.input().path, '**', filename), recursive=True)[0]
 
 class ImportAllTables(BaseParams, WrapperTask):
 

--- a/tasks/br/data.py
+++ b/tasks/br/data.py
@@ -122,6 +122,7 @@ class ImportData(CSV2TempTableTask):
 
         return os.path.join(self.input().path, '{tablename}_{state_code}.csv'.format(tablename=self.tablename,
                                                                                      state_code=state_code))
+
     def _datafile_path(self, tablename, state_code):
         filename = '{tablename}[-_]{state_code}.[xX][lL][sS]'.format(tablename=tablename,
                                                                      state_code=state_code)


### PR DESCRIPTION
Fixes Domicilio02 table. This table was updated in 2018 to delete some redundant columns (always NULL). However, when doing so, the ID's got broken as well. Instead of the proper IDs, all the rows contain `55031E+14`, which looks like a configuration problem when generating the files.

Luckily, all files in the sector have the same rows in the same order, so we can recover them from another file. Furthermore, I have a 2017 backups of the older files (which have the correct IDs). A `diff` of the old file against the one generated by this patch shows no difference in data (just a change in the header row, removing some extra columns as mentioned above).