### PR TITLE
Fix acs 2010 2014

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,10 +406,16 @@ uk-census-middle-super-output-areas:
 	make -- run uk.census.wrapper.CensusMiddleSuperOutputAreas
 
 ### us
-us-all: us-bls us-acs-2015 us-acs-2016 us-lodes us-spielman us-tiger-2015 us-tiger-2016 us-enviroatlas us-huc us-zillow
+us-all: us-bls us-acs-2010 us-acs-2014 us-acs-2015 us-acs-2016 us-lodes us-spielman us-tiger-2015 us-tiger-2016 us-enviroatlas us-huc us-zillow
 
 us-bls:
 	make -- run us.bls.AllQCEW --maxtimespan 2017Q1
+
+us-acs-2010:
+	make -- run us.census.acs.ACSAll --year 2010
+
+us-acs-2014:
+	make -- run us.census.acs.ACSAll --year 2014
 
 us-acs-2015:
 	make -- run us.census.acs.ACSAll --year 2015

--- a/tasks/us/census/acs.py
+++ b/tasks/us/census/acs.py
@@ -38,10 +38,6 @@ SAMPLES = [SAMPLE_5YR, SAMPLE_1YR]
 MINIMUM_TIGER_YEAR = 2015
 
 
-def tiger_year_for_acs(acs_year):
-    return str(max(MINIMUM_TIGER_YEAR, int(acs_year)))
-
-
 class DownloadACS(LoadPostgresFromZipFile):
 
     # http://censusreporter.tumblr.com/post/73727555158/easier-access-to-acs-data
@@ -81,15 +77,14 @@ class Quantiles(TableTask):
     geography = Parameter()
 
     def requires(self):
-        tiger_year = tiger_year_for_acs(self.year)
         return {
             'columns': QuantileColumns(year=self.year, sample=self.sample, geography=self.geography),
             'table': Extract(year=self.year,
                              sample=self.sample,
                              geography=self.geography),
-            'tiger': GeoidColumns(year=tiger_year),
-            'sumlevel': SumLevel(geography=self.geography, year=tiger_year),
-            'shorelineclip': ShorelineClip(geography=self.geography, year=tiger_year)
+            'tiger': GeoidColumns(year=self.tiger_year()),
+            'sumlevel': SumLevel(geography=self.geography, year=self.tiger_year()),
+            'shorelineclip': ShorelineClip(geography=self.geography, year=self.tiger_year())
         }
 
     def version(self):
@@ -104,8 +99,8 @@ class Quantiles(TableTask):
     def columns(self):
         input_ = self.input()
         columns = OrderedDict({
-            'geoidsl': input_['tiger'][self.geography + '_{}'.format(self.year) + GEOID_SUMLEVEL_COLUMN],
-            'geoidsc': input_['tiger'][self.geography + '_{}'.format(self.year) + GEOID_SHORELINECLIPPED_COLUMN]
+            'geoidsl': input_['tiger'][self.geography + '_{}'.format(self.tiger_year()) + GEOID_SUMLEVEL_COLUMN],
+            'geoidsc': input_['tiger'][self.geography + '_{}'.format(self.tiger_year()) + GEOID_SHORELINECLIPPED_COLUMN]
         })
         columns.update(input_['columns'])
         return columns
@@ -114,6 +109,9 @@ class Quantiles(TableTask):
         sample = int(self.sample[0])
         return get_timespan('{start} - {end}'.format(start=int(self.year) - sample + 1,
                                                      end=int(self.year)))
+
+    def tiger_year(self):
+        return str(max(MINIMUM_TIGER_YEAR, int(self.year)))
 
     def populate(self):
         connection = current_session()
@@ -179,17 +177,16 @@ class Extract(TableTask):
         return 14
 
     def requires(self):
-        tiger_year = tiger_year_for_acs(self.year)
         dependencies = {
             'acs': Columns(year=self.year, sample=self.sample, geography=self.geography),
-            'tiger': GeoidColumns(year=tiger_year),
+            'tiger': GeoidColumns(year=self.tiger_year()),
             'data': DownloadACS(year=self.year, sample=self.sample),
-            'sumlevel': SumLevel(geography=self.geography, year=tiger_year),
-            'shorelineclip': ShorelineClip(geography=self.geography, year=tiger_year)
+            'sumlevel': SumLevel(geography=self.geography, year=self.tiger_year()),
+            'shorelineclip': ShorelineClip(geography=self.geography, year=self.tiger_year())
         }
 
         if self.geography == BLOCK:
-            dependencies['interpolation'] = TigerBlocksInterpolation(year=tiger_year)
+            dependencies['interpolation'] = TigerBlocksInterpolation(year=self.tiger_year())
             dependencies['bg_extract'] = Extract(geography=BLOCK_GROUP, sample=self.sample, year=self.year)
 
         return dependencies
@@ -198,6 +195,9 @@ class Extract(TableTask):
         sample = int(self.sample[0])
         return get_timespan('{start} - {end}'.format(start=int(self.year) - sample + 1,
                                                      end=int(self.year)))
+
+    def tiger_year(self):
+        return str(max(MINIMUM_TIGER_YEAR, int(self.year)))
 
     def targets(self):
         return {
@@ -208,8 +208,8 @@ class Extract(TableTask):
     def columns(self):
         input_ = self.input()
         cols = OrderedDict([
-            ('geoidsl', input_['tiger'][self.geography + '_{}'.format(self.year) + GEOID_SUMLEVEL_COLUMN]),
-            ('geoidsc', input_['tiger'][self.geography + '_{}'.format(self.year) + GEOID_SHORELINECLIPPED_COLUMN]),
+            ('geoidsl', input_['tiger'][self.geography + '_{}'.format(self.tiger_year()) + GEOID_SUMLEVEL_COLUMN]),
+            ('geoidsc', input_['tiger'][self.geography + '_{}'.format(self.tiger_year()) + GEOID_SHORELINECLIPPED_COLUMN]),
         ])
         for colkey, col in input_['acs'].items():
             cols[colkey] = col

--- a/tasks/us/census/acs.py
+++ b/tasks/us/census/acs.py
@@ -8,6 +8,7 @@ from tasks.base_tasks import TableTask, MetaWrapper, LoadPostgresFromZipFile, Re
 from tasks.util import grouper
 from tasks.us.census.tiger import SumLevel, ShorelineClip, TigerBlocksInterpolation
 from tasks.us.census.tiger import (SUMLEVELS, GeoidColumns, GEOID_SUMLEVEL_COLUMN, GEOID_SHORELINECLIPPED_COLUMN)
+from tasks.us.census.tiger import YEARS as TIGER_YEARS
 from tasks.meta import (current_session, GEOM_REF)
 from .acs_columns.columns import QuantileColumns, Columns
 
@@ -35,7 +36,6 @@ GEOGRAPHIES = [STATE, COUNTY, CENSUS_TRACT, BLOCK_GROUP, BLOCK, PUMA, ZCTA5, CON
                CBSA, PLACE]
 YEARS = ['2010', '2014', '2015', '2016']
 SAMPLES = [SAMPLE_5YR, SAMPLE_1YR]
-MINIMUM_TIGER_YEAR = 2015
 
 
 class DownloadACS(LoadPostgresFromZipFile):
@@ -111,7 +111,7 @@ class Quantiles(TableTask):
                                                      end=int(self.year)))
 
     def tiger_year(self):
-        return str(max(MINIMUM_TIGER_YEAR, int(self.year)))
+        return str(max(int(self.year), min(TIGER_YEARS)))
 
     def populate(self):
         connection = current_session()
@@ -197,7 +197,7 @@ class Extract(TableTask):
                                                      end=int(self.year)))
 
     def tiger_year(self):
-        return str(max(MINIMUM_TIGER_YEAR, int(self.year)))
+        return str(max(int(self.year), min(TIGER_YEARS)))
 
     def targets(self):
         return {

--- a/tasks/us/census/tiger.py
+++ b/tasks/us/census/tiger.py
@@ -30,6 +30,7 @@ LOGGER = get_logger(__name__)
 GEOID_SUMLEVEL_COLUMN = "_geoidsl"
 GEOID_SHORELINECLIPPED_COLUMN = "_geoidsc"
 BLOCK = 'block'
+YEARS = [2015, 2016]
 
 
 class TigerSourceTags(TagsTask):

--- a/tasks/us/zillow.py
+++ b/tasks/us/zillow.py
@@ -375,8 +375,8 @@ class Zillow(TableTask):
             raise Exception('unrecognized geography {}'.format(self.geography))
 
         columns = OrderedDict([
-            ('region_name_sl', input_['geoids']['{}_{}{}'.format(tiger_geo,TIGER_YEAR,GEOID_SUMLEVEL_COLUMN)]),
-            ('region_name_sc', input_['geoids']['{}_{}{}'.format(tiger_geo,TIGER_YEAR,GEOID_SUMLEVEL_COLUMN)]),
+            ('region_name_sl', input_['geoids']['{}_{}{}'.format(tiger_geo, TIGER_YEAR, GEOID_SUMLEVEL_COLUMN)]),
+            ('region_name_sc', input_['geoids']['{}_{}{}'.format(tiger_geo, TIGER_YEAR, GEOID_SHORELINECLIPPED_COLUMN)]),
         ])
         columns.update(input_['metadata'])
 


### PR DESCRIPTION
Point to 2015 geographies to keep retrocompatibility and save disk space, even if it is wrong to do so.