### PR TITLE
Fixes for uk

### DIFF
--- a/tasks/uk/hierarchy.py
+++ b/tasks/uk/hierarchy.py
@@ -21,7 +21,8 @@ LEVEL_CLASSES = {
     'datashare_pa_geo': PostcodeAreas
 }
 
-LEVELS = list(LEVEL_CLASSES.keys())
+# LEVEL_CLASSES.keys() can't be used because it doesn't guarantee order
+LEVELS = ['cdrc_the_geom', 'odl_ps_geo', 'gov_lsoa_geo', 'gov_msoa_geo', 'odl_pd_geo', 'datashare_pa_geo']
 
 
 def geography(level):

--- a/tasks/uk/hierarchy.py
+++ b/tasks/uk/hierarchy.py
@@ -1,4 +1,5 @@
 from lib.logger import get_logger
+from collections import OrderedDict
 from tasks.hierarchy import DenormalizedHierarchy, GetParentsFunction, \
     Hierarchy, HierarchyInfoUnion, HierarchyChildParentsUnion, \
     HierarchyChildParent, LevelHierarchy, LevelInfo
@@ -12,17 +13,16 @@ LOGGER = get_logger(__name__)
 
 COUNTRY = 'uk'
 
-LEVEL_CLASSES = {
+LEVEL_CLASSES = OrderedDict({
     'cdrc_the_geom': OutputAreas,
     'odl_ps_geo': PostcodeSectors,
     'gov_lsoa_geo': LowerLayerSuperOutputAreas,
     'gov_msoa_geo': MiddleLayerSuperOutputAreas,
     'odl_pd_geo': PostcodeDistricts,
     'datashare_pa_geo': PostcodeAreas
-}
+})
 
-# LEVEL_CLASSES.keys() can't be used because it doesn't guarantee order
-LEVELS = ['cdrc_the_geom', 'odl_ps_geo', 'gov_lsoa_geo', 'gov_msoa_geo', 'odl_pd_geo', 'datashare_pa_geo']
+LEVELS = list(LEVEL_CLASSES.keys())
 
 
 def geography(level):

--- a/tasks/uk/odl.py
+++ b/tasks/uk/odl.py
@@ -222,7 +222,7 @@ class PostcodeSectorsColumns(ColumnsTask):
 
     @staticmethod
     def geoname_column():
-        return 'geographycode'
+        return 'geographyname'
 
     @staticmethod
     def geoid_column():

--- a/tasks/uk/odl.py
+++ b/tasks/uk/odl.py
@@ -260,7 +260,7 @@ class PostcodeSectors(TableTask):
 
         query = '''
                 INSERT INTO {output}
-                SELECT ST_MakeValid(wkb_geometry), replace(name, ' ', '_'), name
+                SELECT ST_MakeValid(wkb_geometry), name, name
                 FROM {input}
                 '''.format(output=self.output().table,
                            input=self.input()['data'].table)


### PR DESCRIPTION
This addresses CartoDB/bigmetadata/issues/612.

I've also made a minor fix and some integration tests at CartoDB/do_tiler/pull/59 (and added a nice-to-have).

First CR, for acceptance I'll move the data (12 and 13 from XYZ table, postcode units and sectors MC tables and UK names tables) to staging and ask for acceptance.

Code is now fixed (so running it from scratch will generate the right data), but I'll apply the fix manually on top of current data.

Export:
```sh
psql -U postgres gis --port 5555 --host 0.0.0.0 -Atc "copy (select * from tiler.xyz_uk_do_geoms where z in (12, 13)) to stdout" > ./xyz_uk_do_geoms_12_13.dump'
pg_dump -U docker -d gis --port 5555 --host 0.0.0.0 -d gis -t "\"uk.mastercard\".mc_postcode_unit" > ./mc_postcode_unit.dump
pg_dump -U docker -d gis --port 5555 --host 0.0.0.0 -d gis -t "\"uk.mastercard\".mc_postcode_sector" > ./mc_postcode_sector.dump
pg_dump -U docker -d gis --port 5555 --host 0.0.0.0 -d gis -t "tiler.uk_dz_hierarchy_geonames_2011" > ./uk_dz_hierarchy_geonames_2011.dump
```

Import:

```sh
psql -U postgres gis -Atc 'DELETE FROM tiler.xyz_uk_do_geoms WHERE z IN (12, 13);
cat /tmp/xyz_uk_do_geoms_12_13.dump | psql -U postgres -d gis -Atc "copy tiler.xyz_uk_do_geoms from stdin"

psql -U postgres gis -Atc 'DROP TABLE "uk.mastercard".mc_postcode_unit'
cat /tmp/mc_postcode_unit.dump | psql -U postgres -d gis
psql -U postgres gis -Atc 'DROP TABLE "uk.mastercard".mc_postcode_sector'
cat /tmp/mc_postcode_sector.dump | psql -U postgres -d gis
psql -U postgres gis -Atc 'GRANT USAGE ON SCHEMA "uk.mastercard" TO geocoder_api; GRANT SELECT ON ALL TABLES IN SCHEMA "uk.mastercard" TO geocoder_api;'

psql -U postgres gis -Atc 'DROP TABLE tiler.uk_dz_hierarchy_geonames_2011'
cat /tmp/uk_dz_hierarchy_geonames_2011.dump | psql -U postgres -d gis
psql -U postgres gis -Atc 'GRANT USAGE ON SCHEMA tiler TO geocoder_api; GRANT SELECT ON ALL TABLES IN SCHEMA tiler TO geocoder_api;'
```