### PR TITLE
update canada statistics 2016 download link

### DIFF
--- a/tasks/ca/statcan/census2016/data.py
+++ b/tasks/ca/statcan/census2016/data.py
@@ -35,7 +35,7 @@ GEOLEVEL_FROM_GEOGRAPHY = {
 }
 
 # https://www12.statcan.gc.ca/census-recensement/2016/dp-pd/prof/details/download-telecharger/comp/page_dl-tc.cfm?Lang=E
-URL = 'https://www12.statcan.gc.ca/census-recensement/2016/dp-pd/prof/details/download-telecharger/comp/GetFile.cfm?Lang=E&TYPE=CSV&GEONO={geo_code}'
+URL = 'https://www12.statcan.gc.ca/census-recensement/2016/dp-pd/prof/details/download-telecharger/comp/GetFile.cfm?Lang=E&FILETYPE=CSV&GEONO={geo_code}'
 NUM_MEASUREMENTS = 2247
 
 


### PR DESCRIPTION
Seems they changed the URL. For instance, see:

Old link: https://www12.statcan.gc.ca/census-recensement/2016/dp-pd/prof/details/download-telecharger/comp/GetFile.cfm?Lang=E&TYPE=CSV&GEONO=044

New link: https://www12.statcan.gc.ca/census-recensement/2016/dp-pd/prof/details/download-telecharger/comp/GetFile.cfm?Lang=E&FILETYPE=CSV&GEONO=044